### PR TITLE
Feature: Fully implement logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='1.0.0',
+    version='1.1.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     keywords=['gis'],
     install_requires=[
         'docopt==0.6.*',
-        'pandas==1.*',
         'arcgis==1.8.*',
     ],
     extras_require={

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -79,7 +79,6 @@ def log_report(report_dict, report_file, separator='|', rotate_count=18):
     for agol_id, item_report_dict in report_dict.items():
         item_list = [agol_id]
         item_list.extend([str(item_report_dict[col]) for col in columns])
-        print(item_list)
         report_logger.info(separator.join(item_list))
 
 

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -85,7 +85,7 @@ class Auditor:
         'Online. There may (or may not) be a newer vintage of this dataset in the SGID.</i>'
     )
 
-    def __init__(self, verbose=False):
+    def __init__(self, log, verbose=False):
         """
         Create an arcgis.gis.GIS object using the user, portal, and password set in credentials.py. Automatically
         create a list of all the Feature Service objects in the user's folders and a dictionary of each item's folder
@@ -121,6 +121,8 @@ class Auditor:
         self.username = credentials.USERNAME
 
         self.metadata_xml_template = credentials.XML_TEMPLATE
+
+        self.log = log
 
         #: TODO: Wrap in a method, call via retry()
         try:
@@ -216,6 +218,8 @@ class Auditor:
         'report_dir', if specified.
         """
 
+        self.log.info(f'Checking {len(self.feature_service_items)} items...')
+
         counter = 0
         try:
             for item in self.feature_service_items:
@@ -265,6 +269,8 @@ class Auditor:
         self.report_dict and writes the whole dictionary to a csv named
         checks_yyyy-mm-dd.csv in 'report_path' (if specified).
         """
+
+        self.log.info(f'Fixing {len(self.report_dict)} items...')
 
         counter = 0
         try:
@@ -316,7 +322,7 @@ class Auditor:
 
         except KeyboardInterrupt:
             print('Interrupted by Ctrl-c')
-            raise   
+            raise
 
         finally:
             #: Convert dict to pandas df for easy writing
@@ -329,7 +335,9 @@ class Auditor:
                 for fix_type in self.fix_counts:
                     fix = fix_type.rpartition('_')[0]  #: will be used later to ignore certain fix counts
                     if fix not in ['thumbnail']:
-                        print(f'{self.fix_counts[fix_type]} items updated for {fix_type}')
+                        self.log.info(f'{self.fix_counts[fix_type]} items updated for {fix_type}')
+            else:
+                self.log.info('No items fixed.')
 
             if not self.verbose:
                 scratch_path = Path(arcpy.env.scratchFolder)

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -316,7 +316,7 @@ class Auditor:
 
         except KeyboardInterrupt:
             print('Interrupted by Ctrl-c')
-            raise
+            raise   
 
         finally:
             #: Convert dict to pandas df for easy writing
@@ -327,8 +327,9 @@ class Auditor:
 
             if self.fix_counts:
                 for fix_type in self.fix_counts:
-                    # fix = fix_type.split('_')[0]  #: will be used later to ignore certain fix counts
-                    print(f'{self.fix_counts[fix_type]} items updated for {fix_type}')
+                    fix = fix_type.rpartition('_')[0]  #: will be used later to ignore certain fix counts
+                    if fix not in ['thumbnail']:
+                        print(f'{self.fix_counts[fix_type]} items updated for {fix_type}')
 
             if not self.verbose:
                 scratch_path = Path(arcpy.env.scratchFolder)

--- a/src/auditor/auditor_pallet.py
+++ b/src/auditor/auditor_pallet.py
@@ -13,6 +13,6 @@ class AuditorPallet(Pallet):
         return True
 
     def process(self):
-        org_auditor = auditor.Auditor()
+        org_auditor = auditor.Auditor(self.log)
         org_auditor.check_items(credentials.REPORT_DIR)
         org_auditor.fix_items(credentials.REPORT_DIR)

--- a/src/auditor/auditor_pallet.py
+++ b/src/auditor/auditor_pallet.py
@@ -3,7 +3,7 @@ auditor_pallet.py: forklift-compliant entry point
 """
 from forklift.models import Pallet
 
-from . import auditor, credentials
+from . import auditor
 
 
 class AuditorPallet(Pallet):
@@ -14,5 +14,5 @@ class AuditorPallet(Pallet):
 
     def process(self):
         org_auditor = auditor.Auditor(self.log)
-        org_auditor.check_items(credentials.REPORT_DIR)
-        org_auditor.fix_items(credentials.REPORT_DIR)
+        org_auditor.check_items(report=False)  #: Don't bother reporting checks
+        org_auditor.fix_items(report=True)

--- a/src/auditor/cli.py
+++ b/src/auditor/cli.py
@@ -2,16 +2,16 @@
 auditor
 
 Usage:
-    auditor [--save_report=<dir> --dry --verbose]
+    auditor [--save_report --dry --verbose]
 
 Options:
     -h, --help
-    -r, --save_report <dir>     Directory to save report to, e.g. `c:\\temp`
+    -r, --save_report           Save report to the file specified in the credentials file (will be rotated)
     -d, --dry                   Only run the checks, don't do any fixes [default: False]
     -v, --verbose               Print status updates to the console [default: False]
 
 Examples:
-    auditor --save_report=c:\\temp -v
+    auditor -r -v
 """
 
 import logging
@@ -37,7 +37,7 @@ def cli():
         print(__doc__)
     else:
 
-        report_dir = args['--save_report']
+        # report_dir = args['--save_report']
 
         cli_logger = logging.getLogger('auditor')
         cli_logger.setLevel(logging.DEBUG)
@@ -50,7 +50,9 @@ def cli():
         cli_logger.addHandler(cli_handler)
 
         org_auditor = Auditor(cli_logger, args['--verbose'])
-        org_auditor.check_items(report_dir)
 
-        if not args['--dry']:
-            org_auditor.fix_items(report_dir)
+        if args['--dry']:
+            org_auditor.check_items(args['--save_report'])
+        else:
+            org_auditor.check_items(report=False)  #: only do the fix report on a full run.
+            org_auditor.fix_items(args['--save_report'])

--- a/src/auditor/cli.py
+++ b/src/auditor/cli.py
@@ -14,6 +14,9 @@ Examples:
     auditor --save_report=c:\\temp -v
 """
 
+import logging
+import sys
+
 from docopt import docopt, DocoptExit
 
 from .auditor import Auditor
@@ -36,7 +39,17 @@ def cli():
 
         report_dir = args['--save_report']
 
-        org_auditor = Auditor(args['--verbose'])
+        cli_logger = logging.getLogger('auditor')
+        cli_logger.setLevel(logging.DEBUG)
+        detailed_formatter = logging.Formatter(
+            fmt='%(levelname)-7s %(asctime)s %(module)10s:%(lineno)5s %(message)s', datefmt='%m-%d %H:%M:%S'
+        )
+        cli_handler = logging.StreamHandler(stream=sys.stdout)
+        cli_handler.setLevel(logging.DEBUG)
+        cli_handler.setFormatter(detailed_formatter)
+        cli_logger.addHandler(cli_handler)
+
+        org_auditor = Auditor(cli_logger, args['--verbose'])
         org_auditor.check_items(report_dir)
 
         if not args['--dry']:

--- a/src/auditor/credentials_template.py
+++ b/src/auditor/credentials_template.py
@@ -9,4 +9,4 @@ THUMBNAIL_DIR = ''  #: Directory with thumbnails named sgid_group.png
 METATABLE = ''  #: Full path to SGID.META.AGOLItems metatable
 AGOL_TABLE = ''  #: URL for Feature Service REST endpoint for AGOL-hosted metatable
 XML_TEMPLATE = ''  #: Path to 'exact copy of.xslt' template
-REPORT_DIR = ''  #: Directory to dump report CSVs detailing everything that was fixed
+REPORT_BASE_PATH = ''  #: File path for report CSVs of everything that was fixed; rotated on each run

--- a/src/auditor/fixes.py
+++ b/src/auditor/fixes.py
@@ -72,10 +72,10 @@ class ItemFixer:
 
         #:item.update() returns False if it fails
         if not update_result:
-            self.item_report['title_result'] = f'Failed to update title to "{title}"'
+            self.item_report['title_result'] = f'Failed to update title to \'{title}\''
             return
 
-        self.item_report['title_result'] = f'Updated title to "{title}"'
+        self.item_report['title_result'] = f'Updated title to \'{title}\''
 
     def group_fix(self, groups_dict):
         """
@@ -101,15 +101,15 @@ class ItemFixer:
 
             #: Report if we couldn't share it with group
             if gid in result_dict['notSharedWith']:
-                self.item_report['groups_result'] = f'Failed to share with everyone and "{group_name}" group'
+                self.item_report['groups_result'] = f'Failed to share with everyone and \'{group_name}\' group'
                 return
 
         #: Groups should always be found, but in case they're not, report
         except KeyError:
-            self.item_report['groups_result'] = f'Cannot find group "{group_name}" in organization'
+            self.item_report['groups_result'] = f'Cannot find group \'{group_name}\' in organization'
             return
 
-        self.item_report['groups_result'] = f'Shared with everyone and "{group_name}" group'
+        self.item_report['groups_result'] = f'Shared with everyone and \'{group_name}\' group'
 
     def folder_fix(self):
         """
@@ -130,16 +130,16 @@ class ItemFixer:
 
         #: .move(folder) returns None if folder not found
         if not move_result:
-            self.item_report['folder_result'] = f'"{folder}" folder not found'
+            self.item_report['folder_result'] = f'\'{folder}\' folder not found'
             return
 
         #: Catching any other abnormal result
         if not move_result['success']:
-            self.item_report['folder_result'] = f'Failed to move item to "{folder}" folder'
+            self.item_report['folder_result'] = f'Failed to move item to \'{folder}\' folder'
             return
 
         #: If all the checks have passed, return good result.
-        self.item_report['folder_result'] = f'Item moved to "{folder}" folder'
+        self.item_report['folder_result'] = f'Item moved to \'{folder}\' folder'
 
     def delete_protection_fix(self):
         """
@@ -224,14 +224,14 @@ class ItemFixer:
             self.item.update(metadata=str(metadata_xml_path))
 
             if self.item.metadata != arcpy_metadata.xml:
-                self.item_report['metadata_result'] = f'Tried to update metadata from "{fc_path}; verify manually"'
+                self.item_report['metadata_result'] = f'Tried to update metadata from \'{fc_path}\'; verify manually'
                 return
 
         except ValueError:
-            self.item_report['metadata_result'] = f'Metadata too long to upload from "{fc_path}" (>32,767 characters)'
+            self.item_report['metadata_result'] = f'Metadata too long to upload from \'{fc_path}\' (>32,767 characters)'
             return
 
-        self.item_report['metadata_result'] = f'Metadata updated from "{fc_path}"'
+        self.item_report['metadata_result'] = f'Metadata updated from \'{fc_path}\''
 
     def description_note_fix(self, static_note, shelved_note):
         """
@@ -303,11 +303,11 @@ class ItemFixer:
 
         try:
             self.item.content_status = new_authoritative
-            self.item_report['authoritative_result'] = f'Content status updated to "{new_authoritative}"'
+            self.item_report['authoritative_result'] = f'Content status updated to \'{new_authoritative}\''
             return
 
         except ValueError:
-            self.item_report['authoritative_result'] = f'Invalid new authoritative value "{new_authoritative}"'
+            self.item_report['authoritative_result'] = f'Invalid new authoritative value \'{new_authoritative}\''
             return
 
         except RuntimeError:


### PR DESCRIPTION
auditor now uses python's `logging` module for all logging and reporting. 

- `auditor` object now requires a log object to be passed in at instantiation
  - Enables use of either forklift logger via the pallet or a stand-alone logger via the CLI
- Check/fix report moved from pandas' `to_csv()` to a `|`-delimited csv written by a rotating file logger independent of the main logger
  - Independent logger allows different file location than main forklift log 
  - removes pandas dependency
- A few critical checkpoints and a brief summary of fixes are written to the main logger at INFO level.
- Item-by-item `print()`s left under the `-v` switch for monitoring progress on CLI  
- Cleaned `auditor` interface: all report paths come from credentials file, moving all credentials file calls inside `auditor.py` instead of having some in `auditor_pallet.py`
  - More consistency between `cli.py` and `auditor_pallet.py`

Closes #12 