### PR TITLE
fix: skip non-agol metatable rows. closes #30

### DIFF
--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -249,8 +249,6 @@ class Auditor:
                 try:
                     uuid.UUID(table_agol_itemid)
                 except (AttributeError, ValueError, TypeError):
-                    if self.verbose:
-                        print(f'{table_sgid_name} from {table} table not in AGOL')
                     continue
 
                 if table_agol_itemid not in self.metatable_dict:

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -367,10 +367,8 @@ class Auditor:
                         continue
 
                     #: Increment fixed item summary statistic
-                    if status in self.fix_counts:
-                        self.fix_counts[status] += 1
-                    else:
-                        self.fix_counts[status] = 1
+                    self.fix_counts.setdefault(status, 0)
+                    self.fix_counts[status] += 1
                     #: Log actual fixes
                     if self.verbose:
                         print(f'\t{item_report[status]}')

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -359,16 +359,21 @@ class Auditor:
                     'authoritative_result', 'visibility_result'
                 ]
 
+                #: Update summary statistics, print results if verbose
                 for status in update_status_keys:
-                    if 'No update needed for' not in item_report[status]:
-                        #: Increment fixed item summary statistic
-                        if status in self.fix_counts:
-                            self.fix_counts[status] += 1
-                        else:
-                            self.fix_counts[status] = 1
-                        #: Log actual fixes
-                        if self.verbose:
-                            print(f'\t{item_report[status]}')
+
+                    #: Skip statuses not updated
+                    if 'No update needed for' in item_report[status]:
+                        continue
+
+                    #: Increment fixed item summary statistic
+                    if status in self.fix_counts:
+                        self.fix_counts[status] += 1
+                    else:
+                        self.fix_counts[status] = 1
+                    #: Log actual fixes
+                    if self.verbose:
+                        print(f'\t{item_report[status]}')
 
         except KeyboardInterrupt:
             print('Interrupted by Ctrl-c')


### PR DESCRIPTION
Checks the itemid for each metatable row to see if it's a valid UUID. If it isn't, it skips adding that row to the internal metatable dict used when checking various parts of each AGOL item. This allows us to use magic words in the itemid row to indicate layers aren't in AGOL (mainly for layers that we're accessing from other orgs' AGOL).