### PR TITLE
Find and report duplicate item titles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='1.2.0',
+    version='1.3.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -358,6 +358,8 @@ class Auditor:
 
     def check_organization_wide(self):
 
+        self.log.info('Running organization-wide checks...')
+
         #: Run organization-wide checks
         organization_checker = org_checker.OrgChecker(self.items_to_check)
         org_results = organization_checker.run_checks()
@@ -368,6 +370,8 @@ class Auditor:
                 self.log.info(f'{check} results ({len(check_results_dict)}):')
                 for key, value in check_results_dict.items():
                     self.log.info(f'{key}: {value}')
+            else:
+                self.log.info(f'{check} returned no results')
 
 
     def fix_items(self, report=False):

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -14,7 +14,7 @@ from time import sleep
 import arcgis
 import arcpy
 
-from . import checks, fixes, credentials
+from . import checks, fixes, credentials, org_checker
 
 
 def retry(worker, verbose=True, tries=1):
@@ -355,6 +355,20 @@ class Auditor:
         finally:
             if report:
                 log_report(self.report_dict, credentials.REPORT_BASE_PATH)
+
+    def check_organization_wide(self):
+
+        #: Run organization-wide checks
+        organization_checker = org_checker.OrgChecker(self.items_to_check)
+        org_results = organization_checker.run_checks()
+
+        #: Log results to main logger
+        for check, check_results_dict in org_results.items():
+            if check_results_dict:
+                self.log.info(f'{check} results ({len(check_results_dict)}):')
+                for key, value in check_results_dict.items():
+                    self.log.info(f'{key}: {value}')
+
 
     def fix_items(self, report=False):
         """

--- a/src/auditor/auditor_pallet.py
+++ b/src/auditor/auditor_pallet.py
@@ -14,5 +14,6 @@ class AuditorPallet(Pallet):
 
     def process(self):
         org_auditor = auditor.Auditor(self.log)
+        org_auditor.check_organization_wide()
         org_auditor.check_items(report=False)  #: Don't bother reporting checks
         org_auditor.fix_items(report=True)

--- a/src/auditor/cli.py
+++ b/src/auditor/cli.py
@@ -52,6 +52,7 @@ def cli():
 
         org_auditor = Auditor(cli_logger, args['--verbose'], args['ITEM'])
 
+        org_auditor.check_organization_wide()
         if args['--dry']:
             org_auditor.check_items(args['--save_report'])
         else:

--- a/src/auditor/org_checker.py
+++ b/src/auditor/org_checker.py
@@ -1,0 +1,42 @@
+"""
+Holds an OrgChecker object that runs checks at the organization level (instead of at the item level)
+"""
+
+
+class OrgChecker:
+    """
+    An OrgChecker runs checks at the org level, as opposed to the item level. For example, checking whether there are
+    any items with the same title.
+
+    To use, instantiate and then call run_checks(), which will run all checks.
+    """
+
+    def __init__(self, item_list):
+        self.item_list = item_list
+
+    def run_checks(self):
+        """
+        Run all checks in the OrgChecker. Any new checks should be added to this method.
+        """
+
+        self.check_for_duplicate_titles()
+
+    def check_for_duplicate_titles(self):
+        """
+        Report any items in self.item_list that have duplicate titles.
+
+        Returns: Dictionary of item ids for each duplicate title: {duplicate_title: [itemid, itemid, ...]}
+        """
+        seen_titles = {}
+        duplicates = {}
+        for item in self.item_list:
+            if item.title in seen_titles:
+                seen_titles[item.title].append(item.itemid)
+            else:
+                seen_titles[item.title] = [item.itemid]
+
+        for title in seen_titles:
+            if len(seen_titles[title]) > 1:
+                duplicates[title] = seen_titles[title]
+
+        return duplicates

--- a/src/auditor/org_checker.py
+++ b/src/auditor/org_checker.py
@@ -19,7 +19,11 @@ class OrgChecker:
         Run all checks in the OrgChecker. Any new checks should be added to this method.
         """
 
-        self.check_for_duplicate_titles()
+        results_dict = {}
+
+        results_dict['check_for_duplicate_titles'] = self.check_for_duplicate_titles()
+
+        return results_dict
 
     def check_for_duplicate_titles(self):
         """

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -148,7 +148,7 @@ def test_org_checker_completes_and_logs(mocker, caplog):
     cli_logger = logging.getLogger('test')
 
     agol_item = namedtuple('agol_item', ['title', 'itemid'])
-    item_list = [agol_item('foo', 1), agol_item('bar', 2), agol_item('foo', 3)]
+    item_list = [agol_item('foo', 1), agol_item('foo', 2)]
 
     mocker.patch('auditor.auditor.Auditor.setup')
     
@@ -158,4 +158,20 @@ def test_org_checker_completes_and_logs(mocker, caplog):
         test_auditor.check_organization_wide()
 
         assert 'check_for_duplicate_titles results (1):' in caplog.text
-        assert 'foo: [1, 3]' in caplog.text
+        assert 'foo: [1, 2]' in caplog.text
+
+def test_org_checker_reports_no_results(mocker, caplog):
+
+    cli_logger = logging.getLogger('test')
+
+    agol_item = namedtuple('agol_item', ['title', 'itemid'])
+    item_list = [agol_item('foo', 1), agol_item('bar', 2)]
+
+    mocker.patch('auditor.auditor.Auditor.setup')
+    
+    test_auditor = Auditor(cli_logger, verbose=True)
+    test_auditor.items_to_check = item_list
+    with caplog.at_level(logging.DEBUG, logger='test'):
+        test_auditor.check_organization_wide()
+
+        assert 'check_for_duplicate_titles returned no results' in caplog.text

--- a/tests/test_org_checker.py
+++ b/tests/test_org_checker.py
@@ -1,0 +1,21 @@
+from collections import namedtuple
+
+from auditor.org_checker import OrgChecker
+
+
+def test_duplicate_item_titles_added_to_dict(mocker):
+    agol_item = namedtuple('agol_item', ['title', 'itemid'])
+    item_list = [agol_item('foo', 1), agol_item('bar', 2), agol_item('foo', 3)]
+
+    dupe_checker = OrgChecker(item_list)
+    dupes = dupe_checker.check_for_duplicate_titles()
+
+    assert dupes == {'foo': [1, 3]}
+
+
+def test_duplicate_checker_called_once(mocker):
+
+    mocker.patch('auditor.org_checker.OrgChecker.check_for_duplicate_titles')
+    dupe_checker = OrgChecker(['empty list'])
+    dupe_checker.run_checks()
+    OrgChecker.check_for_duplicate_titles.assert_called_once()


### PR DESCRIPTION
Searches all the user's hosted feature services for duplicate titles and reports them in the main log (not the separate report log). 

Closes #27 