### PR TITLE
Check and fix cacheMaxAge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='1.3.0',
+    version='1.4.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='1.4.0',
+    version='1.3.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '
@@ -27,7 +27,7 @@ setup(
     zip_safe=True,
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: System Administrators',
         'Topic :: Utilities',
     ],

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -415,11 +415,12 @@ class Auditor:
                 retry(fixer.thumbnail_fix)
                 retry(fixer.authoritative_fix)
                 retry(fixer.visibility_fix)
+                retry(fixer.cache_age_fix)
 
                 update_status_keys = [
                     'metadata_result', 'tags_result', 'title_result', 'groups_result', 'folder_result',
                     'delete_protection_result', 'downloads_result', 'description_note_result', 'thumbnail_result',
-                    'authoritative_result', 'visibility_result'
+                    'authoritative_result', 'visibility_result', 'cache_age_result'
                 ]
 
                 #: Update summary statistics, print results if verbose

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -374,7 +374,6 @@ class Auditor:
             else:
                 self.log.info(f'{check} returned no results')
 
-
     def fix_items(self, report=False):
         """
         Instantiates an ItemFixer for each item and manually runs the specified

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -348,6 +348,7 @@ class Auditor:
                 checker.thumbnail_check(credentials.THUMBNAIL_DIR)
                 retry(checker.authoritative_check)
                 retry(checker.visibility_check)
+                retry(lambda: checker.cache_age_check(credentials.CACHE_MAX_AGE))  # pylint: disable=cell-var-from-loop
 
                 #: Add results to the report
                 self.report_dict[itemid].update(checker.results_dict)

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -88,6 +88,13 @@ class ItemChecker:
         self.item = item
         self.metatable_dict = metatable_dict
 
+        #: Get the REST properties object once
+        try:
+            manager = arcgis.features.FeatureLayerCollection.fromitem(self.item).manager
+            self.properties = json.loads(str(manager.properties))
+        except:  # pylint: disable=bare-except
+            self.properties = None
+
         #: These may or may not be used outside their specific check methods
         self.new_tags = []
         self.downloads = False
@@ -483,3 +490,22 @@ class ItemChecker:
             fix_visibility['visibility_fix'] = 'Y'
 
         self.results_dict.update(fix_visibility)
+
+    def cache_age_check(self, max_age):
+        """
+        Make sure the cacheMaxAge setting matches the desired time. Sets the "Cache Control" value in the AGOL
+        item settings.
+
+        Update results_dict with results for this item:
+                {'cache_age_fix':'', 'cache_age_old':'', 'cache_age_new:''}
+        """
+
+        #: Create protect data: downloads_fix
+        fix_cache_age = {'cache_age_fix': 'N', 'cache_age_old': '', 'cache_age_new': ''}
+
+        if self.in_sgid and self.properties:
+            current_age = self.properties['adminServiceInfo']['cacheMaxAge']
+            if current_age != max_age:
+                fix_cache_age = {'cache_age_fix': 'Y', 'cache_age_old': current_age, 'cache_age_new': max_age}
+
+        self.results_dict.update(fix_cache_age)

--- a/src/auditor/credentials_template.py
+++ b/src/auditor/credentials_template.py
@@ -10,3 +10,4 @@ METATABLE = ''  #: Full path to SGID.META.AGOLItems metatable
 AGOL_TABLE = ''  #: URL for Feature Service REST endpoint for AGOL-hosted metatable
 XML_TEMPLATE = ''  #: Path to 'exact copy of.xslt' template
 REPORT_BASE_PATH = ''  #: File path for report CSVs of everything that was fixed; rotated on each run
+CACHE_MAX_AGE = None  #: Number of seconds for the Cache Control/cacheMaxAge property (int)

--- a/src/auditor/fixes.py
+++ b/src/auditor/fixes.py
@@ -342,3 +342,27 @@ class ItemFixer:
             return
 
         self.item_report['visibility_result'] = 'Default visibility set to True'
+
+    def cache_age_fix(self):
+        """
+        Create a FeatureLayerCollection from item and use it's manager object to
+        change the cacheAgeMax property
+
+        Updates item_report with results for this fix:
+        {cache_age_result: result}
+        """
+
+        if self.item_report['cache_age_fix'].casefold() != 'y':
+            self.item_report['cache_age_result'] = 'No update needed for cacheAgeMax'
+            return
+
+        new_age = self.item_report['cache_age_new']
+
+        manager = arcgis.features.FeatureLayerCollection.fromitem(self.item).manager
+        cache_age_result = manager.update_definition({'cache_age_max': new_age})
+
+        if not cache_age_result['success']:
+            self.item_report['cache_age_result'] = f'Failed to set cacheAgeMax to {new_age}'
+            return
+
+        self.item_report['cache_age_result'] = f'cacheAgeMax set to {new_age}'

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -151,7 +151,7 @@ def test_org_checker_completes_and_logs(mocker, caplog):
     item_list = [agol_item('foo', 1), agol_item('foo', 2)]
 
     mocker.patch('auditor.auditor.Auditor.setup')
-    
+
     test_auditor = Auditor(cli_logger, verbose=True)
     test_auditor.items_to_check = item_list
     with caplog.at_level(logging.DEBUG, logger='test'):
@@ -159,6 +159,7 @@ def test_org_checker_completes_and_logs(mocker, caplog):
 
         assert 'check_for_duplicate_titles results (1):' in caplog.text
         assert 'foo: [1, 2]' in caplog.text
+
 
 def test_org_checker_reports_no_results(mocker, caplog):
 
@@ -168,7 +169,7 @@ def test_org_checker_reports_no_results(mocker, caplog):
     item_list = [agol_item('foo', 1), agol_item('bar', 2)]
 
     mocker.patch('auditor.auditor.Auditor.setup')
-    
+
     test_auditor = Auditor(cli_logger, verbose=True)
     test_auditor.items_to_check = item_list
     with caplog.at_level(logging.DEBUG, logger='test'):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,9 @@
 # import arcgis
 
+import unittest
+
+from collections import namedtuple
+
 from auditor import credentials
 from auditor import checks
 from auditor.auditor import Auditor
@@ -32,3 +36,38 @@ def test_upercased_tags():
 
 # def test_meta_tag_removal():
 #     test_tag = 'Required: Common-Use Word Or Phrase Used To Describe the Subject of the Data Set'
+
+
+def test_max_age_fixes_different_time(mocker):
+
+    item = mocker.Mock()
+    item.in_sgid = True
+    item.properties = {'adminServiceInfo' : {'cacheMaxAge': -1}}
+    item.results_dict = {}
+
+    checks.ItemChecker.cache_age_check(item, 5)
+
+    assert item.results_dict == {'cache_age_fix': 'Y', 'cache_age_old': -1, 'cache_age_new': 5}
+
+
+def test_max_age_doesnt_fix_same_time(mocker):
+
+    item = mocker.Mock()
+    item.in_sgid = True
+    item.properties = {'adminServiceInfo' : {'cacheMaxAge': 5}}
+    item.results_dict = {}
+
+    checks.ItemChecker.cache_age_check(item, 5)
+
+    assert item.results_dict == {'cache_age_fix': 'N', 'cache_age_old':'', 'cache_age_new':''}
+
+
+def test_max_age_ignores_non_sgid_item(mocker):
+
+    item = mocker.Mock()
+    item.in_sgid = False
+    item.results_dict = {}
+
+    checks.ItemChecker.cache_age_check(item, 5)
+
+    assert item.results_dict == {'cache_age_fix': 'N', 'cache_age_old': '', 'cache_age_new': ''}

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -42,7 +42,7 @@ def test_max_age_fixes_different_time(mocker):
 
     item = mocker.Mock()
     item.in_sgid = True
-    item.properties = {'adminServiceInfo' : {'cacheMaxAge': -1}}
+    item.properties = {'adminServiceInfo': {'cacheMaxAge': -1}}
     item.results_dict = {}
 
     checks.ItemChecker.cache_age_check(item, 5)
@@ -54,12 +54,12 @@ def test_max_age_doesnt_fix_same_time(mocker):
 
     item = mocker.Mock()
     item.in_sgid = True
-    item.properties = {'adminServiceInfo' : {'cacheMaxAge': 5}}
+    item.properties = {'adminServiceInfo': {'cacheMaxAge': 5}}
     item.results_dict = {}
 
     checks.ItemChecker.cache_age_check(item, 5)
 
-    assert item.results_dict == {'cache_age_fix': 'N', 'cache_age_old':'', 'cache_age_new':''}
+    assert item.results_dict == {'cache_age_fix': 'N', 'cache_age_old': '', 'cache_age_new': ''}
 
 
 def test_max_age_ignores_non_sgid_item(mocker):

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -2,6 +2,7 @@ from auditor.fixes import ItemFixer
 
 
 def test_cache_age_fix_runs_on_Y(mocker):
+    
     update_def_mock = mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition')
     mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
 
@@ -14,8 +15,6 @@ def test_cache_age_fix_runs_on_Y(mocker):
 
 
 def test_cache_age_fix_doesnt_run_on_N(mocker):
-    # mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition')
-    # mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
 
     fixer_item = mocker.Mock()
     fixer_item.item_report = {'cache_age_fix': 'N'}
@@ -27,8 +26,12 @@ def test_cache_age_fix_doesnt_run_on_N(mocker):
 
 def test_cache_age_fix_sets_correct_results(mocker):
 
-    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
-    mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition', return_value = {'success': True})
+    mock_manager = mocker.Mock()
+    mock_manager.update_definition.return_value = {'success': True}
+    mock_flc = mocker.Mock()
+    mock_flc.manager = mock_manager
+
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value = mock_flc)
 
     fixer_item = mocker.Mock()
     fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
@@ -40,8 +43,12 @@ def test_cache_age_fix_sets_correct_results(mocker):
 
 def test_cache_age_reports_failed_fix(mocker):
 
-    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
-    mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition', return_value = {'success': False})
+    mock_manager = mocker.Mock()
+    mock_manager.update_definition.return_value = {'success': False}
+    mock_flc = mocker.Mock()
+    mock_flc.manager = mock_manager
+
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value = mock_flc)
 
     fixer_item = mocker.Mock()
     fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -2,7 +2,7 @@ from auditor.fixes import ItemFixer
 
 
 def test_cache_age_fix_runs_on_Y(mocker):
-    
+
     update_def_mock = mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition')
     mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
 
@@ -31,7 +31,7 @@ def test_cache_age_fix_sets_correct_results(mocker):
     mock_flc = mocker.Mock()
     mock_flc.manager = mock_manager
 
-    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value = mock_flc)
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value=mock_flc)
 
     fixer_item = mocker.Mock()
     fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
@@ -48,7 +48,7 @@ def test_cache_age_reports_failed_fix(mocker):
     mock_flc = mocker.Mock()
     mock_flc.manager = mock_manager
 
-    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value = mock_flc)
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem', return_value=mock_flc)
 
     fixer_item = mocker.Mock()
     fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
@@ -56,4 +56,3 @@ def test_cache_age_reports_failed_fix(mocker):
     ItemFixer.cache_age_fix(fixer_item)
 
     assert fixer_item.item_report['cache_age_result'] == 'Failed to set cacheAgeMax to 5'
-

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,52 @@
+from auditor.fixes import ItemFixer
+
+
+def test_cache_age_fix_runs_on_Y(mocker):
+    update_def_mock = mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition')
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
+
+    fixer_item = mocker.Mock()
+    fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
+
+    ItemFixer.cache_age_fix(fixer_item)
+
+    assert update_def_mock.called_called_once()
+
+
+def test_cache_age_fix_doesnt_run_on_N(mocker):
+    # mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition')
+    # mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
+
+    fixer_item = mocker.Mock()
+    fixer_item.item_report = {'cache_age_fix': 'N'}
+
+    ItemFixer.cache_age_fix(fixer_item)
+
+    assert fixer_item.item_report['cache_age_result'] == 'No update needed for cacheAgeMax'
+
+
+def test_cache_age_fix_sets_correct_results(mocker):
+
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
+    mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition', return_value = {'success': True})
+
+    fixer_item = mocker.Mock()
+    fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
+
+    ItemFixer.cache_age_fix(fixer_item)
+
+    assert fixer_item.item_report['cache_age_result'] == 'cacheAgeMax set to 5'
+
+
+def test_cache_age_reports_failed_fix(mocker):
+
+    mocker.patch('arcgis.features.FeatureLayerCollection.fromitem')
+    mocker.patch('arcgis.features.managers.FeatureLayerCollectionManager.update_definition', return_value = {'success': False})
+
+    fixer_item = mocker.Mock()
+    fixer_item.item_report = {'cache_age_fix': 'Y', 'cache_age_new': 5}
+
+    ItemFixer.cache_age_fix(fixer_item)
+
+    assert fixer_item.item_report['cache_age_result'] == 'Failed to set cacheAgeMax to 5'
+


### PR DESCRIPTION
Checks and fixes the cacheMaxAge property for any AGOL hosted feature service in the SGID. Value (in seconds) is specified in the credentials file. 

Closes #35 