### PR TITLE
Group item property calls for performance increase

### DIFF
--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -317,10 +317,13 @@ class Auditor:
 
         self.log.info(f'Checking {len(self.items_to_check)} items')
 
+        times = []
+
         counter = 0
         try:
             for item in self.items_to_check:
 
+                start = datetime.datetime.now()
                 counter += 1
 
                 if self.verbose:
@@ -353,9 +356,15 @@ class Auditor:
                 #: Add results to the report
                 self.report_dict[itemid].update(checker.results_dict)
 
+                end = datetime.datetime.now()
+                times.append((str(end - start), item.title))
+
         finally:
             if report:
                 log_report(self.report_dict, credentials.REPORT_BASE_PATH)
+
+            for time in times:
+                print(time)
 
     def check_organization_wide(self):
 

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -317,13 +317,10 @@ class Auditor:
 
         self.log.info(f'Checking {len(self.items_to_check)} items')
 
-        times = []
-
         counter = 0
         try:
             for item in self.items_to_check:
 
-                start = datetime.datetime.now()
                 counter += 1
 
                 if self.verbose:
@@ -356,15 +353,9 @@ class Auditor:
                 #: Add results to the report
                 self.report_dict[itemid].update(checker.results_dict)
 
-                end = datetime.datetime.now()
-                times.append((str(end - start), item.title))
-
         finally:
             if report:
                 log_report(self.report_dict, credentials.REPORT_BASE_PATH)
-
-            for time in times:
-                print(time)
 
     def check_organization_wide(self):
 

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -4,6 +4,7 @@ checks.py: contains ItemChecker class for evaluating an item's metadata, etc and
 import json
 
 from pathlib import Path
+from collections import namedtuple
 
 import arcgis
 import arcpy
@@ -61,6 +62,32 @@ def get_group_from_table(metatable_dict_entry):
     return group
 
 
+def get_item_properties(item):
+    ItemProperties = namedtuple(
+        'ItemProperties',
+        ['title', 'tags', 'shared_with', 'itemid', 'protected', 'description', 'metadata', 'content_status', 'layers']
+    )
+
+    title = item.title
+    tags = item.tags
+    try:
+        shared_with = item.shared_with
+    except:
+        shared_with = Exception
+    itemid = item.itemid
+    protected = item.protected
+    description = item.description
+    metadata = item.metadata
+    content_status = item.content_status
+    layers = item.layers
+
+    item_properties = ItemProperties(
+        title, tags, shared_with, itemid, protected, description, metadata, content_status, layers
+    )
+
+    return item_properties
+
+
 class ItemChecker:
     """
     Class to check an AGOL item. Uses a metatable entry for most information;
@@ -85,7 +112,8 @@ class ItemChecker:
         self.results_dict = {}
         self.results_dict['SGID_Name'] = ''
 
-        self.item = item
+        # self.item = item
+        self.item = get_item_properties(item)
         self.metatable_dict = metatable_dict
 
         #: Get the REST properties object once

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -63,6 +63,9 @@ def get_group_from_table(metatable_dict_entry):
 
 
 def get_item_properties(item):
+    """
+    Gets all the relevant info about item in successive calls; seems to speed up times by about .5 to 1 second per item. 
+    """
     ItemProperties = namedtuple(
         'ItemProperties',
         ['title', 'tags', 'shared_with', 'itemid', 'protected', 'description', 'metadata', 'content_status', 'layers']
@@ -72,7 +75,7 @@ def get_item_properties(item):
     tags = item.tags
     try:
         shared_with = item.shared_with
-    except:
+    except:  # pylint: disable=bare-except
         shared_with = Exception
     itemid = item.itemid
     protected = item.protected
@@ -112,7 +115,6 @@ class ItemChecker:
         self.results_dict = {}
         self.results_dict['SGID_Name'] = ''
 
-        # self.item = item
         self.item = get_item_properties(item)
         self.metatable_dict = metatable_dict
 

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -75,8 +75,8 @@ def get_item_properties(item):
     tags = item.tags
     try:
         shared_with = item.shared_with
-    except:  # pylint: disable=bare-except
-        shared_with = Exception
+    except Exception as ex:
+        shared_with = ex
     itemid = item.itemid
     protected = item.protected
     description = item.description

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -64,7 +64,7 @@ def get_group_from_table(metatable_dict_entry):
 
 def get_item_properties(item):
     """
-    Gets all the relevant info about item in successive calls; seems to speed up times by about .5 to 1 second per item. 
+    Gets all the relevant info about item in successive calls; seems to speed up times by about .5 to 1 second per item.
     """
     ItemProperties = namedtuple(
         'ItemProperties',


### PR DESCRIPTION
Grouping as many `item.<property>` calls successively as possible seems to improve speed (perhaps due to network caching or the AAfP not having to recreate a connection?). Testing and profiling indicates it seems to save about .5 to 1 second, which can be a 25%-50% speed boost per item. 

First dry run comparison on the network indicates the new code took ~16 minutes compared to ~35 minutes, but there may have been an AGOL network latency spike in the middle that added some time.

Profiling a single item over VPN yields the following (just including the checks.py calls). Compare the time spent in `get_item_properties` vs the sum of the `_check` methods, especially `groups_check` and `downloads_check` 
<details>
<summary> new code </summary>

```
        1    0.000    0.000    0.898    0.898 checks.py:108(__init__)
        3    0.000    0.000    0.000    0.000 checks.py:13(tag_case)
        1    0.000    0.000    6.320    6.320 checks.py:142(setup)
        1    0.000    0.000    0.000    0.000 checks.py:179(tags_check)
        1    0.000    0.000    0.000    0.000 checks.py:197(<listcomp>)
        1    0.000    0.000    0.000    0.000 checks.py:287(title_check)
        1    0.000    0.000    0.000    0.000 checks.py:304(folder_check)
        1    0.000    0.000    0.100    0.100 checks.py:323(groups_check)
        1    0.000    0.000    0.100    0.100 checks.py:333(<listcomp>)
        1    0.000    0.000    0.000    0.000 checks.py:347(downloads_check)
        1    0.000    0.000    0.000    0.000 checks.py:371(delete_protection_check)
        1    0.000    0.000    0.000    0.000 checks.py:388(metadata_check)
        1    0.000    0.000    0.000    0.000 checks.py:424(description_note_check)
        1    0.000    0.000    0.000    0.000 checks.py:443(thumbnail_check)
        1    0.000    0.000    0.000    0.000 checks.py:469(authoritative_check)
        1    0.000    0.000    0.000    0.000 checks.py:48(get_group_from_table)
        1    0.000    0.000    0.283    0.283 checks.py:495(visibility_check)
        1    0.000    0.000    0.000    0.000 checks.py:522(cache_age_check)
        1    0.000    0.000    0.898    0.898 checks.py:65(get_item_properties)
```
</details>

<details>
<summary>old code </summary>

```
        1    0.000    0.000    1.287    1.287 checks.py:108(__init__)
        3    0.000    0.000    0.000    0.000 checks.py:13(tag_case)
        1    0.000    0.000    6.183    6.183 checks.py:142(setup)
        1    0.000    0.000    0.000    0.000 checks.py:179(tags_check)
        1    0.000    0.000    0.000    0.000 checks.py:197(<listcomp>)
        1    0.000    0.000    0.000    0.000 checks.py:287(title_check)
        1    0.000    0.000    0.000    0.000 checks.py:304(folder_check)
        1    0.000    0.000    0.656    0.656 checks.py:323(groups_check)
        1    0.000    0.000    0.100    0.100 checks.py:333(<listcomp>)
        1    0.000    0.000    0.949    0.949 checks.py:347(downloads_check)
        1    0.000    0.000    0.000    0.000 checks.py:371(delete_protection_check)
        1    0.000    0.000    0.152    0.152 checks.py:388(metadata_check)
        1    0.000    0.000    0.000    0.000 checks.py:424(description_note_check)
        1    0.000    0.000    0.000    0.000 checks.py:443(thumbnail_check)
        1    0.000    0.000    0.000    0.000 checks.py:469(authoritative_check)
        1    0.000    0.000    0.000    0.000 checks.py:48(get_group_from_table)
        1    0.000    0.000    0.267    0.267 checks.py:495(visibility_check)
        1    0.000    0.000    0.000    0.000 checks.py:522(cache_age_check)
```
</details>