### PR TITLE
fix: isolated temp_dir in scratch folder

### DIFF
--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -260,6 +260,13 @@ class Auditor:
         In case of multiple calls (ie, for retry()), all data are re-instantiated/initialized.
         """
 
+        #: temp_dir used by fixes.metadata_fix() to hold xml of sde metadata
+        temp_dir = Path(arcpy.env.scratchFolder, 'auditor')
+        if not temp_dir.exists():
+            if self.verbose:
+                print(f'Creating temp directory {temp_dir}...')
+            temp_dir.mkdir()
+
         self.log.info(f'Logging into {credentials.ORG} as {credentials.USERNAME}')
 
         self.gis = arcgis.gis.GIS(credentials.ORG, credentials.USERNAME, credentials.PASSWORD)
@@ -469,8 +476,8 @@ class Auditor:
                 self.log.info('No items fixed.')
 
             #: Wipe scratch environment unless verbose (to save metadata xmls for troubleshooting)
-            #: TODO: Change so this doesn't stomp other processes using arpcy.env.scratchFolder
+            #: TODO: Create subdir (used in fixes.metadata_fix()) based on date, rather than just "auditor"?
             if not self.verbose:
-                scratch_path = Path(arcpy.env.scratchFolder)
+                scratch_path = Path(arcpy.env.scratchFolder, 'auditor')
                 for child in scratch_path.iterdir():
                     child.unlink()

--- a/src/auditor/fixes.py
+++ b/src/auditor/fixes.py
@@ -213,7 +213,7 @@ class ItemFixer:
 
         item_id = self.item.itemid
         i = 0
-        metadata_xml_path = Path(arcpy.env.scratchFolder, f'{item_id}_{i}.xml')
+        metadata_xml_path = Path(arcpy.env.scratchFolder, 'auditor', f'{item_id}_{i}.xml')
         #: Sometimes a network error leaves a phantom lock on the metadata xml file when retrying. If we can't unlink()
         #: the file, increment its counter and check if it exists again.
         while metadata_xml_path.exists():
@@ -221,7 +221,7 @@ class ItemFixer:
                 metadata_xml_path.unlink()
             except PermissionError:
                 i += 1
-                metadata_xml_path = Path(arcpy.env.scratchFolder, f'{item_id}_{i}.xml')
+                metadata_xml_path = Path(arcpy.env.scratchFolder, 'auditor', f'{item_id}_{i}.xml')
 
         arcpy_metadata.saveAsUsingCustomXSLT(str(metadata_xml_path), xml_template)
 


### PR DESCRIPTION
Auditor was trying to wipe out everything in `arcpy.env.scratchFolder`, which could a) stomp on other process' data and b) cause IO errors when it doesn't have permission to delete other data. Now it creates its own subfolder and only tries to clean that out.