### PR TITLE
feat: paramaterize log depth

### DIFF
--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -378,7 +378,7 @@ class Auditor:
 
         finally:
             if report:
-                log_report(self.report_dict, credentials.REPORT_BASE_PATH)
+                log_report(self.report_dict, credentials.REPORT_BASE_PATH, rotate_count=credentials.LOG_ROTATE_COUNT)
 
     def check_organization_wide(self):
 
@@ -465,7 +465,7 @@ class Auditor:
 
         finally:
             if report:
-                log_report(self.report_dict, credentials.REPORT_BASE_PATH)
+                log_report(self.report_dict, credentials.REPORT_BASE_PATH, rotate_count=credentials.LOG_ROTATE_COUNT)
 
             if self.fix_counts:
                 for fix_type in self.fix_counts:

--- a/src/auditor/credentials_template.py
+++ b/src/auditor/credentials_template.py
@@ -11,6 +11,7 @@ DB = ''  #: Full path to sde connection file
 METATABLE = ''  #: Full path to SGID.META.AGOLItems metatable
 AGOL_TABLE = ''  #: URL for Feature Service REST endpoint for AGOL-hosted metatable
 REPORT_BASE_PATH = ''  #: File path for report CSVs of everything that was fixed; rotated on each run
+LOG_ROTATE_COUNT = 90  #: Number of logs to rotate through (the n+1 oldest log will be deleted at rotate)
 CACHE_MAX_AGE = None  #: Number of seconds for the Cache Control/cacheMaxAge property (int)
 EMAIL_SETTINGS = {  #: Settings for EmailHandler
     'smtpServer': '',


### PR DESCRIPTION
Moves the rotated log depth setting to credentials.py to allow it to be changed w/o changing the code itself.

Defaulting to ~3 months; experience with `porter` is showing that we may want to be able to go back further than 18 runs (days).