### PR TITLE
Automatically add (Deprecated) to title if metatable indicates dataset is deprecated

### DIFF
--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -221,6 +221,7 @@ class Auditor:
         self.report_dict = {}
 
         #: A list of feature service items to audit
+        #: Order based on CLI or by AGOL folder (and by last updated within each folder?)
         self.items_to_check = []
 
         #: A dictionary of items and their folder

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -303,7 +303,7 @@ class ItemChecker:
         #: If we have a new title from metatable, add and check for deprecated note
         if self.title_from_metatable and self.title_from_metatable != self.item.title:
             new_title = self.title_from_metatable
-            if self.authoritative == 'deprecated' and 'deprecated' not in new_title:
+            if self.authoritative == 'deprecated' and 'deprecated' not in new_title.casefold():
                 new_title += ' (Deprecated)'
 
             title_data = {'title_fix': 'Y', 'title_old': self.item.title, 'title_new': new_title}

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -304,7 +304,7 @@ class ItemChecker:
         if self.title_from_metatable and self.title_from_metatable != self.item.title:
             new_title = self.title_from_metatable
             if self.authoritative == 'deprecated' and 'deprecated' not in new_title.casefold():
-                new_title += ' (Deprecated)'
+                new_title = '{Deprecated} ' + new_title
 
             title_data = {'title_fix': 'Y', 'title_old': self.item.title, 'title_new': new_title}
             self.results_dict.update(title_data)
@@ -316,7 +316,7 @@ class ItemChecker:
             self.title_from_metatable == self.item.title and self.authoritative == 'deprecated' and
             'deprecated' not in self.item.title.casefold()
         ):
-            new_title = self.item.title + ' (Deprecated)'
+            new_title = '{Deprecated} ' + self.item.title
 
             title_data = {'title_fix': 'Y', 'title_old': self.item.title, 'title_new': new_title}
             self.results_dict.update(title_data)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -191,3 +191,27 @@ def test_old_title_retained(mocker):
     checks.ItemChecker.title_check(item_checker)
 
     assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current', 'title_new': ''}
+
+
+def test_deprecated_not_added_to_new_title_if_already_in_title(mocker):
+    item_checker = mocker.Mock()
+    item_checker.authoritative = 'deprecated'
+    item_checker.title_from_metatable = 'new (Deprecated)'
+    item_checker.item.title = 'current'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'current', 'title_new': 'new (Deprecated)'}
+
+
+def test_deprecated_not_added_to_existing_title_if_already_in_title(mocker):
+    item_checker = mocker.Mock()
+    item_checker.authoritative = 'deprecated'
+    item_checker.title_from_metatable = 'current (Deprecated)'
+    item_checker.item.title = 'current (Deprecated)'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current (Deprecated)', 'title_new': ''}

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -154,7 +154,7 @@ def test_deprecated_added_to_existing_title(mocker):
 
     checks.ItemChecker.title_check(item_checker)
 
-    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'foo', 'title_new': 'foo (Deprecated)'}
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'foo', 'title_new': '{Deprecated} foo'}
 
 
 def test_deprecated_added_to_new_title(mocker):
@@ -166,7 +166,7 @@ def test_deprecated_added_to_new_title(mocker):
 
     checks.ItemChecker.title_check(item_checker)
 
-    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'current', 'title_new': 'new (Deprecated)'}
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'current', 'title_new': '{Deprecated} new'}
 
 
 def test_title_updated(mocker):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -95,14 +95,14 @@ def test_max_age_ignores_non_sgid_item(mocker):
 def test_shelved_item_propercased_gets_shelved_thumbnail(mocker):
 
     item = mocker.Mock()
-    item.new_group = 'Shelved'
+    item.new_group = 'AGRC Shelf'
     item.results_dict = {}
 
     thumbnail_dir = Path(__file__).parents[1] / 'thumbnails'
 
     checks.ItemChecker.thumbnail_check(item, thumbnail_dir)
 
-    assert item.results_dict == {'thumbnail_fix': 'Y', 'thumbnail_path': str(thumbnail_dir / 'shelved.png')}
+    assert item.results_dict == {'thumbnail_fix': 'Y', 'thumbnail_path': str(thumbnail_dir / 'shelf.png')}
 
 
 def test_same_group_doesnt_update_thumbnail(mocker):
@@ -134,7 +134,7 @@ def test_report_invalid_thumbnail_path(mocker):
 
 def test_correct_thumbnails_dir(mocker):
     item = mocker.Mock()
-    item.new_group = 'Shelved'
+    item.new_group = 'AGRC Shelf'
     item.results_dict = {}
 
     repo_path = Path(__file__).parents[1]
@@ -142,4 +142,52 @@ def test_correct_thumbnails_dir(mocker):
 
     checks.ItemChecker.thumbnail_check(item, thumbnail_path)
 
-    assert item.results_dict == {'thumbnail_fix': 'Y', 'thumbnail_path': str(thumbnail_path / 'shelved.png')}
+    assert item.results_dict == {'thumbnail_fix': 'Y', 'thumbnail_path': str(thumbnail_path / 'shelf.png')}
+
+
+def test_deprecated_added_to_existing_title(mocker):
+    item_checker = mocker.Mock()
+    item_checker.authoritative = 'deprecated'
+    item_checker.title_from_metatable = 'foo'
+    item_checker.item.title = 'foo'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'foo', 'title_new': 'foo (Deprecated)'}
+
+
+def test_deprecated_added_to_new_title(mocker):
+    item_checker = mocker.Mock()
+    item_checker.authoritative = 'deprecated'
+    item_checker.title_from_metatable = 'new'
+    item_checker.item.title = 'current'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'current', 'title_new': 'new (Deprecated)'}
+
+
+def test_title_updated(mocker):
+    item_checker = mocker.Mock()
+    # item_checker.authoritative = None
+    item_checker.title_from_metatable = 'new'
+    item_checker.item.title = 'current'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'Y', 'title_old': 'current', 'title_new': 'new'}
+
+
+def test_old_title_retained(mocker):
+    item_checker = mocker.Mock()
+    # item_checker.authoritative = None
+    item_checker.title_from_metatable = 'current'
+    item_checker.item.title = 'current'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current', 'title_new': ''}


### PR DESCRIPTION
Auditor will now add ~` (Deprecated)` to the title~ `{Deprecated}` to the beginning of the title if the `Authoritative` field is `d` and `deprecated` is not already in the title. If it is already in the title, it leaves it there.

Fixes issue raised in https://github.com/agrc/porter/pull/122