### PR TITLE
Deprecated title hotfix

### DIFF
--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -298,35 +298,27 @@ class ItemChecker:
         #: Always include the old title for readability
         title_data = {'title_fix': 'N', 'title_old': self.item.title, 'title_new': ''}
 
-        new_title = None
+        #: Will be updated from metatable and/or deprecated check.
+        new_title = self.item.title
 
-        #: If we have a new title from metatable, add and check for deprecated note
-        if self.title_from_metatable and self.title_from_metatable != self.item.title:
+        #: Existing title with {Deprecated} removed if necessary
+        existing_title = self.item.title
+        if self.item.title.startswith('{Deprecated} '):
+            existing_title = self.item.title.split(' ', 1)[-1]
+
+        #: Check to see if title needs updating from metatable, taking into account the metatable title
+        #: won't have {Deprecated} at the front
+        if self.title_from_metatable and self.title_from_metatable != existing_title:
             new_title = self.title_from_metatable
-            if self.authoritative == 'deprecated' and 'deprecated' not in new_title.casefold():
-                new_title = '{Deprecated} ' + new_title
-
             title_data = {'title_fix': 'Y', 'title_old': self.item.title, 'title_new': new_title}
-            self.results_dict.update(title_data)
 
-            return
-
-        #: If we don't have a new title, check for deprecated note
-        if (
-            self.title_from_metatable == self.item.title and self.authoritative == 'deprecated' and
-            'deprecated' not in self.item.title.casefold()
-        ):
-            new_title = '{Deprecated} ' + self.item.title
-
+        #: Add {Deprecated} if necessary
+        #: new_title will have been modified from previous step if necessary
+        if self.authoritative == 'deprecated' and 'deprecated' not in new_title.casefold():
+            new_title = '{Deprecated} ' + new_title
             title_data = {'title_fix': 'Y', 'title_old': self.item.title, 'title_new': new_title}
-            self.results_dict.update(title_data)
 
-            return
-
-        #: Otherwise, just return the no-changes info
         self.results_dict.update(title_data)
-
-        return
 
     def folder_check(self, itemid_and_folder):
         """

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -193,7 +193,7 @@ def test_old_title_retained(mocker):
     assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current', 'title_new': ''}
 
 
-def test_deprecated_not_added_to_new_title_if_already_in_title(mocker):
+def test_deprecated_not_added_to_new_title_if_already_in_new_metadata_title(mocker):
     item_checker = mocker.Mock()
     item_checker.authoritative = 'deprecated'
     item_checker.title_from_metatable = 'new (Deprecated)'
@@ -215,3 +215,15 @@ def test_deprecated_not_added_to_existing_title_if_already_in_title(mocker):
     checks.ItemChecker.title_check(item_checker)
 
     assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current (Deprecated)', 'title_new': ''}
+
+
+def test_deprecated_not_added_to_new_title_if_already_in_item_title(mocker):
+    item_checker = mocker.Mock()
+    item_checker.authoritative = 'deprecated'
+    item_checker.title_from_metatable = 'current'
+    item_checker.item.title = '{Deprecated} current'
+    item_checker.results_dict = {}
+
+    checks.ItemChecker.title_check(item_checker)
+
+    assert item_checker.results_dict == {'title_fix': 'N', 'title_old': '{Deprecated} current', 'title_new': ''}

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -171,7 +171,6 @@ def test_deprecated_added_to_new_title(mocker):
 
 def test_title_updated(mocker):
     item_checker = mocker.Mock()
-    # item_checker.authoritative = None
     item_checker.title_from_metatable = 'new'
     item_checker.item.title = 'current'
     item_checker.results_dict = {}
@@ -183,7 +182,6 @@ def test_title_updated(mocker):
 
 def test_old_title_retained(mocker):
     item_checker = mocker.Mock()
-    # item_checker.authoritative = None
     item_checker.title_from_metatable = 'current'
     item_checker.item.title = 'current'
     item_checker.results_dict = {}
@@ -217,7 +215,7 @@ def test_deprecated_not_added_to_existing_title_if_already_in_title(mocker):
     assert item_checker.results_dict == {'title_fix': 'N', 'title_old': 'current (Deprecated)', 'title_new': ''}
 
 
-def test_deprecated_not_added_to_new_title_if_already_in_item_title(mocker):
+def test_deprecated_not_added_to_existing_title_if_already_prefixes_title(mocker):
     item_checker = mocker.Mock()
     item_checker.authoritative = 'deprecated'
     item_checker.title_from_metatable = 'current'


### PR DESCRIPTION
Auditor kept fixing the title for `{Deprecated} Name` titles. This fix should just do it once, with a new test case added to catch it in the future. 