### PR TITLE
feat: update to use sendgrid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         'docopt==0.6.*',
         'arcgis==1.8.*',
-        'agrc-supervisor',
+        'agrc-supervisor==2.*',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='2.2.1',
+    version='2.3.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '

--- a/src/auditor/credentials_template.py
+++ b/src/auditor/credentials_template.py
@@ -20,3 +20,9 @@ EMAIL_SETTINGS = {  #: Settings for EmailHandler
     'to_addresses': '',
     'prefix': f'Auditor on {socket.gethostname()}: ',
 }
+SENDGRID_SETTINGS = {  #: Settings for SendGridHandler
+    'api_key': '',
+    'from_address': '',
+    'to_addresses': '',
+    'prefix': f'Auditor on {socket.gethostname()}: ',
+}


### PR DESCRIPTION
Closes #56.

Client changes required:

- bump `agrc-supervisor` dependency to 2.x
- add `SendGridHandler` instead of `EmailHandler`
- move `project_name` argument from `Supervisor` call to `SendGridHandler` call
- remove `project_name` from any `MessageDetails` objects
- remove any `<pre>` added for formatting purposes
- add `SENDGRID_SETTINGS` to `credentials.py`, specifying to, from, prefix, and API key. 