### PR TITLE
fix: UGRC rebrand

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 AGRC
+Copyright (c) 2020 UGRC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 UGRC
+Copyright (c) UGRC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -171,11 +171,11 @@ class Auditor:
 
     #: Tags or words that should be uppercased, saved as lower to check against
     uppercased_tags = [
-        '2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'atv', 'blm', 'brat', 'caf', 'cdl', 'dabc', 'daq', 'dem',
-        'dfcm', 'dfirm', 'dnr', 'dogm', 'dot', 'dsl', 'dsm', 'dtm', 'dwq', 'e911', 'ems', 'epa', 'fae', 'fcc', 'fema',
-        'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'ngda', 'nox',
-        'npsbn', 'ntia', 'nwi', 'osa', 'pli', 'plss', 'pm10', 'ppm', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla',
-        'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'uipa', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps',
+        '2g', '3g', '4g', 'agol', 'aog', 'at&t', 'atv', 'blm', 'brat', 'caf', 'cdl', 'dabc', 'daq', 'dem', 'dfcm',
+        'dfirm', 'dnr', 'dogm', 'dot', 'dsl', 'dsm', 'dtm', 'dwq', 'e911', 'ems', 'epa', 'fae', 'fcc', 'fema', 'gcdb',
+        'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'ngda', 'nox', 'npsbn',
+        'ntia', 'nwi', 'osa', 'pli', 'plss', 'pm10', 'ppm', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp',
+        'trax', 'uca', 'udot', 'ugrc', 'ugs', 'uhp', 'uic', 'uipa', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps',
         'ustc', 'ut', 'uta', 'utsc', 'vcp', 'vista', 'voc', 'wbd', 'wre'
     ]
 
@@ -189,6 +189,8 @@ class Auditor:
         'required: common-use word or phrase used to describe the subject of the data set',
         '002',
         'required: common-use word or phrase used to describe the subject of the data set.',
+        'agrc',
+        'AGRC',
     ]
 
     #: Notes for static and shelved descriptions

--- a/src/auditor/auditor.py
+++ b/src/auditor/auditor.py
@@ -190,7 +190,6 @@ class Auditor:
         '002',
         'required: common-use word or phrase used to describe the subject of the data set.',
         'agrc',
-        'AGRC',
     ]
 
     #: Notes for static and shelved descriptions

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -54,7 +54,7 @@ def get_group_from_table(metatable_dict_entry):
     sgid_name, _, item_category, _ = metatable_dict_entry
 
     if item_category == 'shelved':
-        group = 'AGRC Shelf'
+        group = 'UGRC Shelf'
     else:
         table_category = sgid_name.split('.')[1].title()
         group = f'Utah SGID {table_category}'
@@ -176,13 +176,13 @@ class ItemChecker:
                 self.arcpy_metadata = arcpy.metadata.Metadata(str(self.feature_class_path))
 
         #: Get folder from SGID category if it's in the table
-        if self.new_group == 'AGRC Shelf':
-            self.new_folder = 'AGRC_Shelved'
+        if self.new_group == 'UGRC Shelf':
+            self.new_folder = 'UGRC_Shelved'
         elif self.new_group:
             self.new_folder = self.new_group.split('Utah SGID ')[-1]
 
         #: Set static/shelved flag
-        if self.new_group == 'AGRC Shelf':
+        if self.new_group == 'UGRC Shelf':
             self.static_shelved = 'shelved'
         elif self.in_sgid and self.metatable_dict[self.item.itemid][2] == 'static':
             self.static_shelved = 'static'
@@ -442,7 +442,7 @@ class ItemChecker:
             }
 
             # Update flag for description note for shelved/static data
-            if self.new_group == 'AGRC Shelf':
+            if self.new_group == 'UGRC Shelf':
                 metadata_data['metadata_note'] = 'shelved'
             elif self.metatable_dict[self.item.itemid][2] == 'static':
                 metadata_data['metadata_note'] = 'static'

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -280,7 +280,7 @@ class ItemChecker:
                 if 'Shelved' in self.new_tags:
                     self.new_tags.remove('Shelved')
 
-            #: Make sure it's got SGID, AGRC in it's tags
+            #: Make sure it's got SGID, UGRC in it's tags
             if 'SGID' not in self.new_tags:
                 self.new_tags.append('SGID')
             if 'UGRC' not in self.new_tags:

--- a/src/auditor/checks.py
+++ b/src/auditor/checks.py
@@ -15,7 +15,7 @@ def tag_case(tag, uppercased, articles):
     Changes a tag to the correct title case while also removing any periods:
     'U.S. bureau Of Geoinformation' -> 'US Bureau of Geoinformation'. Should
     properly upper-case any words or single tags that are acronyms:
-    'agrc' -> 'AGRC', 'Plss Fabric' -> 'PLSS Fabric'. Any words separated by
+    'ugrc' -> 'UGRC', 'Plss Fabric' -> 'PLSS Fabric'. Any words separated by
     a hyphen will also be title-cased: 'water-related' -> 'Water-Related'.
 
     Note: No check is done for articles at the begining of a tag; all articles
@@ -67,8 +67,17 @@ def get_item_properties(item):
     Gets all the relevant info about item in successive calls; seems to speed up times by about .5 to 1 second per item.
     """
     ItemProperties = namedtuple(
-        'ItemProperties',
-        ['title', 'tags', 'shared_with', 'itemid', 'protected', 'description', 'metadata', 'content_status', 'layers']
+        'ItemProperties', [
+            'title',
+            'tags',
+            'shared_with',
+            'itemid',
+            'protected',
+            'description',
+            'metadata',
+            'content_status',
+            'layers',
+        ]
     )
 
     title = item.title
@@ -183,7 +192,7 @@ class ItemChecker:
         Create a list of new, cleaned tags:
             * Properly case tags using uppercased_tags and articles
             * Delete any tags in tags_to_delete
-            * Add SGID category tag and SGID, AGRC if it's an SGID item
+            * Add SGID category tag and SGID, UGRC if it's an SGID item
 
         Update results_dict with results for this item:
                 {'tags_fix':'', 'tags_old':'', 'tags_new':''}
@@ -274,8 +283,8 @@ class ItemChecker:
             #: Make sure it's got SGID, AGRC in it's tags
             if 'SGID' not in self.new_tags:
                 self.new_tags.append('SGID')
-            if 'AGRC' not in self.new_tags:
-                self.new_tags.append('AGRC')
+            if 'UGRC' not in self.new_tags:
+                self.new_tags.append('UGRC')
 
         #: Create tags data: tags_fix, tags_old, tags_new
         #: Report existing tags for troubleshooting why some items don't seem to be checked during weekly run.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -82,7 +82,7 @@ class TestGroupFromTable:
 
         group = checks.get_group_from_table(metable_row)
 
-        assert group == 'AGRC Shelf'
+        assert group == 'UGRC Shelf'
 
     def test_get_group_from_table_sgid_item(self):
         metable_row = ('SGID.Foo.Bar', '', '', '')
@@ -96,7 +96,7 @@ class TestSetup:
 
     def test_setup_sets_shelved_folder(self, mocker):
         item_checker = mocker.Mock()
-        item_checker.new_group = 'AGRC Shelf'
+        item_checker.new_group = 'UGRC Shelf'
 
         #: Framework for setup to skip parts not testing
         item_checker.item.itemid = '0'
@@ -104,11 +104,11 @@ class TestSetup:
 
         checks.ItemChecker.setup(item_checker, 'foo')
 
-        assert item_checker.new_folder == 'AGRC_Shelved'
+        assert item_checker.new_folder == 'UGRC_Shelved'
 
     def test_setup_sets_shelved_flag(self, mocker):
         item_checker = mocker.Mock()
-        item_checker.new_group = 'AGRC Shelf'
+        item_checker.new_group = 'UGRC Shelf'
 
         #: Framework for setup to skip parts not testing
         item_checker.item.itemid = '0'
@@ -126,7 +126,7 @@ class TestMetadata:
         # item_checker.arcpy_metadata = True
         item_checker.arcpy_metadata.xml = 'foo'
         item_checker.item.metadata = 'bar'
-        item_checker.new_group = 'AGRC Shelf'
+        item_checker.new_group = 'UGRC Shelf'
         item_checker.feature_class_path = 'baz'
         item_checker.results_dict = {}
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -206,7 +206,7 @@ def test_max_age_ignores_non_sgid_item(mocker):
 def test_shelved_item_propercased_gets_shelved_thumbnail(mocker):
 
     item = mocker.Mock()
-    item.new_group = 'AGRC Shelf'
+    item.new_group = 'UGRC Shelf'
     item.results_dict = {}
 
     thumbnail_dir = Path(__file__).parents[1] / 'thumbnails'
@@ -245,7 +245,7 @@ def test_report_invalid_thumbnail_path(mocker):
 
 def test_correct_thumbnails_dir(mocker):
     item = mocker.Mock()
-    item.new_group = 'AGRC Shelf'
+    item.new_group = 'UGRC Shelf'
     item.results_dict = {}
 
     repo_path = Path(__file__).parents[1]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -29,6 +29,52 @@ from auditor.auditor import Auditor
 #     return fake_metatable
 
 
+class TestTagCheck:
+
+    def test_agrc_removed_from_tags(self, mocker):
+        item_checker = mocker.Mock()
+        item_checker.title_from_metatable = 'Utah Foo'
+        item_checker.item.tags = ['AGRC', 'Bar']
+        item_checker.new_tags = []
+        item_checker.results_dict = {}
+        item_checker.arcpy_metadata = False
+        item_checker.new_group = False
+
+        checks.ItemChecker.tags_check(item_checker, Auditor.tags_to_delete, Auditor.uppercased_tags, Auditor.articles)
+
+        assert item_checker.results_dict == {'tags_fix': 'Y', 'tags_old': ['AGRC', 'Bar'], 'tags_new': ['Bar']}
+
+    def test_ugrc_added_to_tags_for_sgid_group_item(self, mocker):
+        item_checker = mocker.Mock()
+        item_checker.title_from_metatable = 'Utah Foo'
+        item_checker.item.tags = []
+        item_checker.new_tags = []
+        item_checker.results_dict = {}
+        item_checker.arcpy_metadata = False
+        item_checker.new_group = 'Utah SGID Bar'
+
+        checks.ItemChecker.tags_check(item_checker, Auditor.tags_to_delete, Auditor.uppercased_tags, Auditor.articles)
+
+        assert item_checker.results_dict == {'tags_fix': 'Y', 'tags_old': [], 'tags_new': ['Bar', 'SGID', 'UGRC']}
+
+    def test_agrc_removed_ugrc_added_to_tags(self, mocker):
+        item_checker = mocker.Mock()
+        item_checker.title_from_metatable = 'Utah Foo'
+        item_checker.item.tags = ['AGRC', 'Bar']
+        item_checker.new_tags = []
+        item_checker.results_dict = {}
+        item_checker.arcpy_metadata = False
+        item_checker.new_group = 'Utah SGID Bar'
+
+        checks.ItemChecker.tags_check(item_checker, Auditor.tags_to_delete, Auditor.uppercased_tags, Auditor.articles)
+
+        assert item_checker.results_dict == {
+            'tags_fix': 'Y',
+            'tags_old': ['AGRC', 'Bar'],
+            'tags_new': ['Bar', 'SGID', 'UGRC']
+        }
+
+
 def test_lowercase_abbreviation_to_uppercase():
     test_tag = 'udot'
     cased = checks.tag_case(test_tag, Auditor.uppercased_tags, Auditor.articles)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -75,6 +75,71 @@ class TestTagCheck:
         }
 
 
+class TestGroupFromTable:
+
+    def test_get_group_from_table_shelved_item(self):
+        metable_row = ('SGID.Foo.Bar', '', 'shelved', '')
+
+        group = checks.get_group_from_table(metable_row)
+
+        assert group == 'AGRC Shelf'
+
+    def test_get_group_from_table_sgid_item(self):
+        metable_row = ('SGID.Foo.Bar', '', '', '')
+
+        group = checks.get_group_from_table(metable_row)
+
+        assert group == 'Utah SGID Foo'
+
+
+class TestSetup:
+
+    def test_setup_sets_shelved_folder(self, mocker):
+        item_checker = mocker.Mock()
+        item_checker.new_group = 'AGRC Shelf'
+
+        #: Framework for setup to skip parts not testing
+        item_checker.item.itemid = '0'
+        item_checker.metatable_dict = {}
+
+        checks.ItemChecker.setup(item_checker, 'foo')
+
+        assert item_checker.new_folder == 'AGRC_Shelved'
+
+    def test_setup_sets_shelved_flag(self, mocker):
+        item_checker = mocker.Mock()
+        item_checker.new_group = 'AGRC Shelf'
+
+        #: Framework for setup to skip parts not testing
+        item_checker.item.itemid = '0'
+        item_checker.metatable_dict = {}
+
+        checks.ItemChecker.setup(item_checker, 'foo')
+
+        assert item_checker.static_shelved == 'shelved'
+
+
+class TestMetadata:
+
+    def test_metadata_check_sets_shelved_note(self, mocker):
+        item_checker = mocker.Mock()
+        # item_checker.arcpy_metadata = True
+        item_checker.arcpy_metadata.xml = 'foo'
+        item_checker.item.metadata = 'bar'
+        item_checker.new_group = 'AGRC Shelf'
+        item_checker.feature_class_path = 'baz'
+        item_checker.results_dict = {}
+
+        checks.ItemChecker.metadata_check(item_checker)
+
+        assert item_checker.results_dict == {
+            'metadata_fix': 'Y',
+            'metadata_old': 'item.metadata from AGOL not shown due to length',
+            'metadata_new': 'baz',
+            'metadata_note': 'shelved'
+        }
+
+
 def test_lowercase_abbreviation_to_uppercase():
     test_tag = 'udot'
     cased = checks.tag_case(test_tag, Auditor.uppercased_tags, Auditor.articles)


### PR DESCRIPTION
Replace any references in Auditor from AGRC to UGRC:

- Tags
- AGRC Shelf group
- AGRC_Shelved folder

Closes #61, waiting on https://github.com/agrc/porter/issues/159.