### PR TITLE
Fix naming, add retry to item get

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='auditor',
-    version='2.4.2',
+    version='3.0.0',
     license='MIT',
     description=(
         'Audits all hosted feature service items in a user\'s AGOL folders for proper tags, sharing, etc based on '

--- a/src/auditor/cli.py
+++ b/src/auditor/cli.py
@@ -29,7 +29,7 @@ from docopt import docopt, DocoptExit
 from supervisor.models import MessageDetails, Supervisor
 from supervisor.message_handlers import SendGridHandler
 
-from .auditor import Auditor, credentials
+from auditor.models import Auditor, credentials
 
 
 def cli():

--- a/src/auditor/cli.py
+++ b/src/auditor/cli.py
@@ -101,3 +101,7 @@ def cli():
             summary_message.subject = f'Auditor Report {datetime.datetime.today()}'
 
             auditor_supervisor.notify(summary_message)
+
+
+if __name__ == '__main__':
+    cli()

--- a/src/auditor/models.py
+++ b/src/auditor/models.py
@@ -1,5 +1,5 @@
 """
-auditor.py
+models.py
 
 See cli.py for usage
 """
@@ -14,7 +14,7 @@ from time import sleep
 import arcgis
 import arcpy
 
-from . import checks, fixes, credentials, org_checker
+from auditor import checks, fixes, credentials, org_checker
 
 
 def retry(worker, verbose=True, tries=1):

--- a/src/auditor/models.py
+++ b/src/auditor/models.py
@@ -415,7 +415,7 @@ class Auditor:
 
                 counter += 1
 
-                item = self.gis.content.get(itemid)  # pylint: disable=no-member
+                item = retry(lambda: self.gis.content.get(itemid))  # pylint: disable=no-member,cell-var-from-loop
                 item_report = self.report_dict[itemid]
 
                 if self.verbose:

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -3,7 +3,7 @@ import logging
 
 from collections import namedtuple
 
-from auditor.auditor import Auditor, retry, Metatable
+from auditor.models import Auditor, retry, Metatable
 
 
 def test_retry():
@@ -29,7 +29,7 @@ def test_read_sgid_metatable_to_dictionary(mocker):
 
     sgid_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_sgid_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_sgid_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', sgid_fields)
@@ -47,7 +47,7 @@ def test_read_agol_metatable_to_dictionary(mocker):
 
     agol_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'CATEGORY']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_agol_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_agol_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', agol_fields)
@@ -64,7 +64,7 @@ def test_magic_string_itemid_not_added_to_dictionary(mocker):
 
     sgid_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_sgid_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_sgid_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', sgid_fields)
@@ -82,7 +82,7 @@ def test_blank_itemid_not_added_to_dictionary(mocker):
 
     sgid_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_sgid_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_sgid_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', sgid_fields)
@@ -101,7 +101,7 @@ def test_duplicate_itemids_in_same_table_reported_in_list(mocker):
 
     sgid_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_sgid_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_sgid_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', sgid_fields)
@@ -128,12 +128,12 @@ def test_duplicate_itemids_from_different_tables_reported_in_list(mocker):
     sgid_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'Authoritative']
     agol_fields = ['TABLENAME', 'AGOL_ITEM_ID', 'AGOL_PUBLISHED_NAME', 'CATEGORY']
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_sgid_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_sgid_row)
 
     test_table = Metatable()
     test_table.read_metatable('something', sgid_fields)
 
-    mocker.patch('auditor.auditor.Metatable._cursor_wrapper', return_agol_row)
+    mocker.patch('auditor.models.Metatable._cursor_wrapper', return_agol_row)
     test_table.read_metatable('agol something', agol_fields)
 
     #: Our duplicate id should be the only entry in .duplicate_keys and .metatable_dict should just have first item
@@ -150,7 +150,7 @@ def test_org_checker_completes_and_logs(mocker, caplog):
     agol_item = namedtuple('agol_item', ['title', 'itemid'])
     item_list = [agol_item('foo', 1), agol_item('foo', 2)]
 
-    mocker.patch('auditor.auditor.Auditor.setup')
+    mocker.patch('auditor.models.Auditor.setup')
 
     test_auditor = Auditor(cli_logger, verbose=True)
     test_auditor.items_to_check = item_list
@@ -168,7 +168,7 @@ def test_org_checker_reports_no_results(mocker, caplog):
     agol_item = namedtuple('agol_item', ['title', 'itemid'])
     item_list = [agol_item('foo', 1), agol_item('bar', 2)]
 
-    mocker.patch('auditor.auditor.Auditor.setup')
+    mocker.patch('auditor.models.Auditor.setup')
 
     test_auditor = Auditor(cli_logger, verbose=True)
     test_auditor.items_to_check = item_list

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from auditor import credentials
 from auditor import checks
-from auditor.auditor import Auditor
+from auditor.models import Auditor
 
 # @pytest.fixture
 # def agol_item():


### PR DESCRIPTION
Wrapped a call to `gis.content.get(itemid)` in retry for robustness.

In the process, renamed `auditor.py` to `models.py` to fix/avoid weird namespace errors between the package name and the module name. This change in the API necessitates a bump to v 3.0.0.

