### PR TITLE
fix: fix handler import

### DIFF
--- a/src/auditor/models.py
+++ b/src/auditor/models.py
@@ -6,6 +6,7 @@ See cli.py for usage
 
 import datetime
 import logging
+from logging.handlers import RotatingFileHandler
 import uuid
 from pathlib import Path
 from time import sleep
@@ -56,7 +57,7 @@ def log_report(report_dict, report_file, separator="|", rotate_count=18):
     #: Set up a rotating file handler for the report log
     report_path = Path(report_file)
     report_logger = logging.getLogger("audit_report")
-    report_handler = logging.handlers.RotatingFileHandler(report_path, backupCount=rotate_count)
+    report_handler = RotatingFileHandler(report_path, backupCount=rotate_count)
     report_handler.doRollover()  #: Rotate the log on each run
     report_handler.setLevel(logging.DEBUG)
     report_logger.addHandler(report_handler)


### PR DESCRIPTION
This started throwing the following error after I upgraded the conda environment from python 3.9 to 3.11:
```
File "C:\dev\auditor\src\auditor\models.py", line 59, in log_report
    report_handler = logging.handlers.RotatingFileHandler(report_path, backupCount=rotate_count)
                     ^^^^^^^^^^^^^^^^

AttributeError: module 'logging' has no attribute 'handlers'
```

I tested the original code in a python 3.8 environment and it fails as well so I have no idea how this worked to begin with.